### PR TITLE
Initial Super Mario Run support

### DIFF
--- a/app/src/main/java/org/nanolx/securitybypasser/XposedEntryPoint.java
+++ b/app/src/main/java/org/nanolx/securitybypasser/XposedEntryPoint.java
@@ -10,6 +10,7 @@ import org.nanolx.securitybypasser.apps.Miitomo;
 import org.nanolx.securitybypasser.apps.MonsterHunterExplore;
 import org.nanolx.securitybypasser.apps.PuzzlesAndDragonsEN;
 import org.nanolx.securitybypasser.apps.PuzzlesAndDragonsJP;
+import org.nanolx.securitybypasser.apps.SuperMarioRun;
 import org.nanolx.securitybypasser.apps.YokaiWatchWW;
 
 import java.util.HashMap;
@@ -31,6 +32,7 @@ public class XposedEntryPoint implements IXposedHookLoadPackage
 		appRegistry.put("com.nexon.hit.global", HIT.class);
 		appRegistry.put("com.square_enix.android_googleplay.khuxww", KingdomHeartsUX.class);
 		appRegistry.put("com.nintendo.zaaa", Miitomo.class);
+		appRegistry.put("com.nintendo.zara", SuperMarioRun.class);
 		appRegistry.put("jp.co.capcom.android.explore", MonsterHunterExplore.class);
 		appRegistry.put("jp.gungho.padEN", PuzzlesAndDragonsEN.class);
 		appRegistry.put("jp.gungho.padHT", PuzzlesAndDragonsJP.class);

--- a/app/src/main/java/org/nanolx/securitybypasser/apps/SuperMarioRun.java
+++ b/app/src/main/java/org/nanolx/securitybypasser/apps/SuperMarioRun.java
@@ -127,5 +127,28 @@ public class SuperMarioRun implements IXposedHookLoadPackage {
                         return false;
                     }
                 });
+        // isSuccess()
+        XposedHelpers.findAndHookMethod("com.snslinkage.dena.snslinkageunityplugin.AttestCall",
+                param.classLoader,
+                "isSuccess",
+                new XC_MethodReplacement() {
+                    @Override
+                    protected Object replaceHookedMethod(MethodHookParam param) throws Throwable {
+                        XposedBridge.log("Nanolx Security Bypasser: Nintendo is trying to stop us, but I won't let it happen!");
+                        XposedBridge.log("Hooked AttestCall.isSuccess()");
+                        return true;
+                    }
+                });
+
+        // String[] packages
+        XposedHelpers.setStaticObjectField(
+                XposedHelpers.findClass("jp.dena.securelib.PrivilegeChecker", param.classLoader),
+                "packages",
+                new String[]{"non.existing.package"});
+        // String[] suExecutables
+        XposedHelpers.setStaticObjectField(
+                XposedHelpers.findClass("jp.dena.securelib.PrivilegeChecker", param.classLoader),
+                "suExecutables",
+                new String[]{"/non/existing/path"});
     }
 }

--- a/app/src/main/java/org/nanolx/securitybypasser/apps/SuperMarioRun.java
+++ b/app/src/main/java/org/nanolx/securitybypasser/apps/SuperMarioRun.java
@@ -23,7 +23,7 @@ public class SuperMarioRun implements IXposedHookLoadPackage {
                     @Override
                     protected Object replaceHookedMethod(MethodHookParam param) throws Throwable {
                         XposedBridge.log("Nanolx Security Bypasser: Nintendo is trying to stop us, but I won't let it happen!");
-                        XposedBridge.log("Hooked PrivilegeChecker.hasPackage())");
+                        XposedBridge.log("Hooked PrivilegeChecker.hasPackage()");
                         return false;
                     }
                 });
@@ -35,7 +35,7 @@ public class SuperMarioRun implements IXposedHookLoadPackage {
                     @Override
                     protected Object replaceHookedMethod(MethodHookParam param) throws Throwable {
                         XposedBridge.log("Nanolx Security Bypasser: Nintendo is trying to stop us, but I won't let it happen!");
-                        XposedBridge.log("Hooked PrivilegeChecker.isDebuggerAttachedJava())");
+                        XposedBridge.log("Hooked PrivilegeChecker.isDebuggerAttachedJava()");
                         return false;
                     }
                 });
@@ -47,7 +47,7 @@ public class SuperMarioRun implements IXposedHookLoadPackage {
                     @Override
                     protected Object replaceHookedMethod(MethodHookParam param) throws Throwable {
                         XposedBridge.log("Nanolx Security Bypasser: Nintendo is trying to stop us, but I won't let it happen!");
-                        XposedBridge.log("Hooked PrivilegeChecker.isDebuggerAttachedNative())");
+                        XposedBridge.log("Hooked PrivilegeChecker.isDebuggerAttachedNative()");
                         return false;
                     }
                 });
@@ -59,7 +59,7 @@ public class SuperMarioRun implements IXposedHookLoadPackage {
                     @Override
                     protected Object replaceHookedMethod(MethodHookParam param) throws Throwable {
                         XposedBridge.log("Nanolx Security Bypasser: Nintendo is trying to stop us, but I won't let it happen!");
-                        XposedBridge.log("Hooked PrivilegeChecker.isDebuggerAttachedNative2())");
+                        XposedBridge.log("Hooked PrivilegeChecker.isDebuggerAttachedNative2()");
                         return false;
                     }
                 });
@@ -71,7 +71,7 @@ public class SuperMarioRun implements IXposedHookLoadPackage {
                     @Override
                     protected Object replaceHookedMethod(MethodHookParam param) throws Throwable {
                         XposedBridge.log("Nanolx Security Bypasser: Nintendo is trying to stop us, but I won't let it happen!");
-                        XposedBridge.log("Hooked PrivilegeChecker.isEmulator())");
+                        XposedBridge.log("Hooked PrivilegeChecker.isEmulator()");
                         return false;
                     }
                 });
@@ -84,7 +84,7 @@ public class SuperMarioRun implements IXposedHookLoadPackage {
                     @Override
                     protected Object replaceHookedMethod(MethodHookParam param) throws Throwable {
                         XposedBridge.log("Nanolx Security Bypasser: Nintendo is trying to stop us, but I won't let it happen!");
-                        XposedBridge.log("Hooked PrivilegeChecker.isRooted())");
+                        XposedBridge.log("Hooked PrivilegeChecker.isRooted()");
                         return false;
                     }
                 });
@@ -97,7 +97,7 @@ public class SuperMarioRun implements IXposedHookLoadPackage {
                     @Override
                     protected Object replaceHookedMethod(MethodHookParam param) throws Throwable {
                         XposedBridge.log("Nanolx Security Bypasser: Nintendo is trying to stop us, but I won't let it happen!");
-                        XposedBridge.log("Hooked PrivilegeChecker.isUSBConnected())");
+                        XposedBridge.log("Hooked PrivilegeChecker.isUSBConnected()");
                         return false;
                     }
                 });
@@ -110,7 +110,7 @@ public class SuperMarioRun implements IXposedHookLoadPackage {
                     @Override
                     protected Object replaceHookedMethod(MethodHookParam param) throws Throwable {
                         XposedBridge.log("Nanolx Security Bypasser: Nintendo is trying to stop us, but I won't let it happen!");
-                        XposedBridge.log("Hooked PrivilegeChecker.isUSBDebugEnabled())");
+                        XposedBridge.log("Hooked PrivilegeChecker.isUSBDebugEnabled()");
                         return false;
                     }
                 });
@@ -123,7 +123,7 @@ public class SuperMarioRun implements IXposedHookLoadPackage {
                     @Override
                     protected Object replaceHookedMethod(MethodHookParam param) throws Throwable {
                         XposedBridge.log("Nanolx Security Bypasser: Nintendo is trying to stop us, but I won't let it happen!");
-                        XposedBridge.log("Hooked PrivilegeChecker.isUSBDebugOptionEnabled())");
+                        XposedBridge.log("Hooked PrivilegeChecker.isUSBDebugOptionEnabled()");
                         return false;
                     }
                 });

--- a/app/src/main/java/org/nanolx/securitybypasser/apps/SuperMarioRun.java
+++ b/app/src/main/java/org/nanolx/securitybypasser/apps/SuperMarioRun.java
@@ -1,0 +1,131 @@
+package org.nanolx.securitybypasser.apps;
+
+import de.robv.android.xposed.IXposedHookLoadPackage;
+import de.robv.android.xposed.XC_MethodReplacement;
+import de.robv.android.xposed.XposedBridge;
+import de.robv.android.xposed.XposedHelpers;
+import de.robv.android.xposed.callbacks.XC_LoadPackage;
+
+/**
+ * Super Mario Run
+ */
+public class SuperMarioRun implements IXposedHookLoadPackage {
+    @Override
+    public void handleLoadPackage(XC_LoadPackage.LoadPackageParam param) throws Throwable {
+        XposedBridge.log("Nanolx Security Bypasser: Entering Super Mario Run.");
+        // hasPackage()
+        XposedHelpers.findAndHookMethod("jp.dena.securelib.PrivilegeChecker",
+                param.classLoader,
+                "hasPackage",
+                "android.content.Context",
+                String.class,
+                new XC_MethodReplacement() {
+                    @Override
+                    protected Object replaceHookedMethod(MethodHookParam param) throws Throwable {
+                        XposedBridge.log("Nanolx Security Bypasser: Nintendo is trying to stop us, but I won't let it happen!");
+                        XposedBridge.log("Hooked PrivilegeChecker.hasPackage())");
+                        return false;
+                    }
+                });
+        // isDebuggerAttachedJava()
+        XposedHelpers.findAndHookMethod("jp.dena.securelib.PrivilegeChecker",
+                param.classLoader,
+                "isDebuggerAttachedJava",
+                new XC_MethodReplacement() {
+                    @Override
+                    protected Object replaceHookedMethod(MethodHookParam param) throws Throwable {
+                        XposedBridge.log("Nanolx Security Bypasser: Nintendo is trying to stop us, but I won't let it happen!");
+                        XposedBridge.log("Hooked PrivilegeChecker.isDebuggerAttachedJava())");
+                        return false;
+                    }
+                });
+        // isDebuggerAttachedNative()
+        XposedHelpers.findAndHookMethod("jp.dena.securelib.PrivilegeChecker",
+                param.classLoader,
+                "isDebuggerAttachedNative",
+                new XC_MethodReplacement() {
+                    @Override
+                    protected Object replaceHookedMethod(MethodHookParam param) throws Throwable {
+                        XposedBridge.log("Nanolx Security Bypasser: Nintendo is trying to stop us, but I won't let it happen!");
+                        XposedBridge.log("Hooked PrivilegeChecker.isDebuggerAttachedNative())");
+                        return false;
+                    }
+                });
+        // isDebuggerAttachedNative2()
+        XposedHelpers.findAndHookMethod("jp.dena.securelib.PrivilegeChecker",
+                param.classLoader,
+                "isDebuggerAttachedNative2",
+                new XC_MethodReplacement() {
+                    @Override
+                    protected Object replaceHookedMethod(MethodHookParam param) throws Throwable {
+                        XposedBridge.log("Nanolx Security Bypasser: Nintendo is trying to stop us, but I won't let it happen!");
+                        XposedBridge.log("Hooked PrivilegeChecker.isDebuggerAttachedNative2())");
+                        return false;
+                    }
+                });
+        // isEmulator()
+        XposedHelpers.findAndHookMethod("jp.dena.securelib.PrivilegeChecker",
+                param.classLoader,
+                "isEmulator",
+                new XC_MethodReplacement() {
+                    @Override
+                    protected Object replaceHookedMethod(MethodHookParam param) throws Throwable {
+                        XposedBridge.log("Nanolx Security Bypasser: Nintendo is trying to stop us, but I won't let it happen!");
+                        XposedBridge.log("Hooked PrivilegeChecker.isEmulator())");
+                        return false;
+                    }
+                });
+        // isRooted()
+        XposedHelpers.findAndHookMethod("jp.dena.securelib.PrivilegeChecker",
+                param.classLoader,
+                "isRooted",
+                "android.content.Context",
+                new XC_MethodReplacement() {
+                    @Override
+                    protected Object replaceHookedMethod(MethodHookParam param) throws Throwable {
+                        XposedBridge.log("Nanolx Security Bypasser: Nintendo is trying to stop us, but I won't let it happen!");
+                        XposedBridge.log("Hooked PrivilegeChecker.isRooted())");
+                        return false;
+                    }
+                });
+        // isUSBConnected()
+        XposedHelpers.findAndHookMethod("jp.dena.securelib.PrivilegeChecker",
+                param.classLoader,
+                "isUSBConnected",
+                "android.content.Context",
+                new XC_MethodReplacement() {
+                    @Override
+                    protected Object replaceHookedMethod(MethodHookParam param) throws Throwable {
+                        XposedBridge.log("Nanolx Security Bypasser: Nintendo is trying to stop us, but I won't let it happen!");
+                        XposedBridge.log("Hooked PrivilegeChecker.isUSBConnected())");
+                        return false;
+                    }
+                });
+        // isUSBDebugEnabled()
+        XposedHelpers.findAndHookMethod("jp.dena.securelib.PrivilegeChecker",
+                param.classLoader,
+                "isUSBDebugEnabled",
+                "android.content.Context",
+                new XC_MethodReplacement() {
+                    @Override
+                    protected Object replaceHookedMethod(MethodHookParam param) throws Throwable {
+                        XposedBridge.log("Nanolx Security Bypasser: Nintendo is trying to stop us, but I won't let it happen!");
+                        XposedBridge.log("Hooked PrivilegeChecker.isUSBDebugEnabled())");
+                        return false;
+                    }
+                });
+        // isUSBDebugOptionEnabled()
+        XposedHelpers.findAndHookMethod("jp.dena.securelib.PrivilegeChecker",
+                param.classLoader,
+                "isUSBDebugOptionEnabled",
+                "android.content.Context",
+                new XC_MethodReplacement() {
+                    @Override
+                    protected Object replaceHookedMethod(MethodHookParam param) throws Throwable {
+                        XposedBridge.log("Nanolx Security Bypasser: Nintendo is trying to stop us, but I won't let it happen!");
+                        XposedBridge.log("Hooked PrivilegeChecker.isUSBDebugOptionEnabled())");
+                        return false;
+                    }
+                });
+    }
+}


### PR DESCRIPTION
Current status:
* You can start the app with this patch and play the first level with it (instead of just crashing at the first splashscreen)
* The game still notices that the phone is rooted and shows the error `804-5100` which apparently only happens on rooted devices.
* I only get the log that `PrivilegeChecker.isEmulator()` is called but no other method (eg `isRooted`). Maybe there is still some problem with hooking or there are other methods of the game to find out if the device is rooted. (`isEmulator` is getting called exactly every 20 seconds)
* Modifying the apk is bad as it seems that the app checks it's own sha1sum (see `jp.dena.securelib.AssetValidator` -> `calcApkFileSHA1`)
* [PrivilegeChecker.java](https://hastebin.com/copuqejefe.java) & [AssetValidator.java](https://hastebin.com/oqesikemom.java) (decompiled with Luyten/Procyon)
* Apparently Super Mario Run uses SafetyNet too... **EDIT:** Maybe fixed with 529399d (another edit: but still getting 804-5100)